### PR TITLE
Fix authOptions usage in overtime API routes

### DIFF
--- a/app/api/overtime/end/route.ts
+++ b/app/api/overtime/end/route.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function POST(req: NextRequest) {
@@ -10,7 +11,7 @@ export async function POST(req: NextRequest) {
       return new NextResponse('Missing userId', { status: 400 })
     }
 
-    const session = await getServerSession()
+  const session = await getServerSession(authOptions)
     if (!session?.user || !(session.user as any).id || (session.user as any).id !== userId) {
       return new NextResponse('Unauthorized', { status: 401 })
     }

--- a/app/api/overtime/route.ts
+++ b/app/api/overtime/route.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(req: NextRequest) {
@@ -11,7 +12,7 @@ export async function GET(req: NextRequest) {
       return new NextResponse('Missing userId', { status: 400 })
     }
 
-    const session = await getServerSession()
+  const session = await getServerSession(authOptions)
     if (!session?.user || !(session.user as any).id || (session.user as any).id !== userId) {
       return new NextResponse('Unauthorized', { status: 401 })
     }

--- a/app/api/overtime/start/route.ts
+++ b/app/api/overtime/start/route.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma'
 import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function POST(req: NextRequest) {
@@ -10,7 +11,7 @@ export async function POST(req: NextRequest) {
       return new NextResponse('Missing userId', { status: 400 })
     }
 
-    const session = await getServerSession()
+  const session = await getServerSession(authOptions)
     if (!session?.user || !(session.user as any).id || (session.user as any).id !== userId) {
       return new NextResponse('Unauthorized', { status: 401 })
     }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma"
 import bcrypt from "bcrypt"
 import { Novu } from '@novu/api'
 import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth"
 
 // 初始化 Novu 客戶端
 const novu = new Novu({ 
@@ -11,7 +12,7 @@ const novu = new Novu({
 
 export async function GET(req: Request) {
   try {
-    const session = await getServerSession()
+    const session = await getServerSession(authOptions)
     
     if (!session?.user?.email) {
       return NextResponse.json({ error: "未登入" }, { status: 401 })


### PR DESCRIPTION
## Summary
- ensure overtime API route handlers include `authOptions` when using `getServerSession`
- apply the same fix to the users API endpoint

## Testing
- `pnpm lint` *(fails: Unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_685b777cfea88328963f9350d8a7aaea