### PR TITLE
Add session check to worklog routes

### DIFF
--- a/app/api/worklog/[id]/route.ts
+++ b/app/api/worklog/[id]/route.ts
@@ -1,5 +1,7 @@
 import { prisma } from '@/lib/prisma'
 import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 
 // 更新工作記錄
 export async function PUT(
@@ -24,6 +26,11 @@ export async function PUT(
       !projectCode || !projectName || !category || !content
     ) {
       return new NextResponse('缺少必要欄位', { status: 400 })
+    }
+
+    const session = await getServerSession(authOptions)
+    if (!session?.user || !(session.user as any).id || (session.user as any).id !== userId) {
+      return new NextResponse('Unauthorized', { status: 401 })
     }
 
     // 檢查工作記錄是否存在且屬於該用戶
@@ -69,6 +76,11 @@ export async function DELETE(
 
     if (!userId) {
       return new NextResponse('缺少 userId', { status: 400 })
+    }
+
+    const session = await getServerSession(authOptions)
+    if (!session?.user || !(session.user as any).id || (session.user as any).id !== userId) {
+      return new NextResponse('Unauthorized', { status: 401 })
     }
 
     // 檢查工作記錄是否存在且屬於該用戶

--- a/app/api/worklog/quick/route.ts
+++ b/app/api/worklog/quick/route.ts
@@ -1,5 +1,7 @@
 import { prisma } from '@/lib/prisma'
 import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 
 export async function POST(req: NextRequest) {
   try {
@@ -8,6 +10,11 @@ export async function POST(req: NextRequest) {
 
     if (!userId || !projectCode || !projectName || !category || !content) {
       return new NextResponse('缺少必要欄位', { status: 400 })
+    }
+
+    const session = await getServerSession(authOptions)
+    if (!session?.user || !(session.user as any).id || (session.user as any).id !== userId) {
+      return new NextResponse('Unauthorized', { status: 401 })
     }
 
     const now = new Date()

--- a/app/api/worklog/route.ts
+++ b/app/api/worklog/route.ts
@@ -1,6 +1,8 @@
 // app/api/worklog/route.ts
 import { prisma } from '@/lib/prisma'
 import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 
 export async function POST(req: NextRequest) {
   try {
@@ -8,7 +10,7 @@ export async function POST(req: NextRequest) {
     if (process.env.NODE_ENV !== 'production') {
       console.log('[POST /api/worklog] 收到的資料:', body)
     }
-    
+
     const {
       userId,
       startTime,
@@ -49,6 +51,11 @@ export async function POST(req: NextRequest) {
     if (endTime && isNaN(endDate!.getTime())) {
       console.error('[POST /api/worklog] 無效的結束時間:', endTime)
       return new NextResponse('無效的結束時間格式', { status: 400 })
+    }
+
+    const session = await getServerSession(authOptions)
+    if (!session?.user || !(session.user as any).id || (session.user as any).id !== userId) {
+      return new NextResponse('Unauthorized', { status: 401 })
     }
 
     if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Summary
- enforce NextAuth session check in worklog APIs

## Testing
- `pnpm install`
- `pnpm lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b8c3f1b588328b62ec8365c712b3e